### PR TITLE
setup scripts for heroku deployment, changed BrowserRouter to HashRouter

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const app = express();
+const path = require('path');
 
 const mongoose = require('mongoose');
 
@@ -29,7 +30,9 @@ app.use(cors(
 const bodyParser = require('body-parser');
 
 // parse application/json
-app.use(bodyParser.json())
+app.use(bodyParser.json());
+
+app.use(express.static(path.join(__dirname, '../frontend/build')));
 
 // routes
 const usersRouter = require('./routes/userRoutes');

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,7 +3,7 @@ import {connect} from 'react-redux';
 
 import Layout from './hoc/Layout';
 
-import { BrowserRouter, Switch, Route, Redirect } from 'react-router-dom'
+import { HashRouter, Switch, Route, Redirect } from 'react-router-dom'
 import Register from './container/Register/Register';
 import Login from './container/Login/Login';
 
@@ -38,11 +38,11 @@ class App extends Component {
         );
       }
       return (
-        <BrowserRouter>
+        <HashRouter>
           <Layout>
             {routes}
           </Layout>
-        </BrowserRouter>
+        </HashRouter>
       );
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "grindandstruggle",
+  "version": "1.0.0",
+  "description": "an app where people can talk about there struggle and grinds",
+  "scripts": {
+    "heroku-postbuild": "npm run install-server && npm run build-client",
+    "start": "node backend/app.js",
+    "install-server": "cd ./backend && npm install",
+    "build-client": "cd ./frontend && npm install && npm run build"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/colorlessenergy/grindandstruggle.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/colorlessenergy/grindandstruggle/issues"
+  },
+  "homepage": "https://github.com/colorlessenergy/grindandstruggle#readme"
+}


### PR DESCRIPTION
add scripts to package.json so heroku can deploy it. Change BrowserRouter to HashRouter to make it easier to make API calls.

add as per issue #36 

* add scripts
* change browserrouter to hashrouter
* expose build folder to the '/' router